### PR TITLE
23 remove responsibility for determining which files are monitored from routewatch

### DIFF
--- a/engine/exec.go
+++ b/engine/exec.go
@@ -30,13 +30,18 @@ func RouteExecOnchanges(ctx context.Context, logger *zap.Logger, param ExecOncha
 		return err
 	}
 
+	globManager, err := fsnotify.NewGlobRuleManager(absRootDir, fsnotify.GlobIncludeRule, param.IncludeRules, param.ExcludeRules)
+	if err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	eventCh := make(chan fsnotify.Event)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if err := fsnotify.RouteWatch(ctx, logger, absRootDir, fsnotify.GlobIncludeRule, param.IncludeRules, param.ExcludeRules, eventCh); err != nil {
+		if err := fsnotify.RouteWatch(ctx, logger, absRootDir, globManager, eventCh); err != nil {
 			logger.Error("error in route watch", zap.Error(err))
 			cancel()
 		}

--- a/fsnotify/fsnotify.go
+++ b/fsnotify/fsnotify.go
@@ -23,7 +23,7 @@ func abs(root, path string) string {
 // Watches the specified directory or files changed.
 //
 // Not that it is designed to be executed persistently.
-func RouteWatch(ctx context.Context, logger *zap.Logger, rootAbsDir string, preferredRule GlobRuleType, includeGlobRules, excludeGlobRules []string, eventReciever chan<- Event) error {
+func RouteWatch(ctx context.Context, logger *zap.Logger, rootAbsDir string, globManager FilepathChecker, eventReciever chan<- Event) error {
 
 	notifier, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -31,10 +31,6 @@ func RouteWatch(ctx context.Context, logger *zap.Logger, rootAbsDir string, pref
 	}
 	defer notifier.Close()
 
-	globManager, err := newGlobRuleManager(rootAbsDir, preferredRule, includeGlobRules, excludeGlobRules)
-	if err != nil {
-		return err
-	}
 	logger.Info("search directories as initialize")
 	addRecursive(rootAbsDir, globManager, notifier)
 
@@ -78,7 +74,7 @@ func IsRemoveEvent(event fsnotify.Event) bool {
 	return event.Op&fsnotify.Remove != 0
 }
 
-func addRecursive(abspath string, manager *GlobRuleManager, watcher *fsnotify.Watcher) error {
+func addRecursive(abspath string, manager FilepathChecker, watcher *fsnotify.Watcher) error {
 	ignoredDirs := map[string]struct{}{}
 
 	return filepath.WalkDir(abspath, func(path string, d fs.DirEntry, err error) error {

--- a/fsnotify/fsnotify_test.go
+++ b/fsnotify/fsnotify_test.go
@@ -11,6 +11,12 @@ import (
 
 func TestFSNotifaction(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
+
+	globManager, err := fsnotify.NewGlobRuleManager("/workspace", fsnotify.GlobIncludeRule, []string{"**.go"}, []string{".git", "**/.git"})
+	if err != nil {
+		logger.Fatal("initialize globManager error", zap.Error(err))
+	}
+
 	wg := sync.WaitGroup{}
 	events := make(chan fsnotify.Event)
 	defer close(events)
@@ -19,7 +25,7 @@ func TestFSNotifaction(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		wg.Done()
-		if err := fsnotify.RouteWatch(ctx, logger, "/workspace", fsnotify.GlobIncludeRule, []string{"**.go"}, []string{".git", "**/.git"}, events); err != nil {
+		if err := fsnotify.RouteWatch(ctx, logger, "/workspace", globManager, events); err != nil {
 			stop()
 		}
 	}()

--- a/fsnotify/glob_rule.go
+++ b/fsnotify/glob_rule.go
@@ -8,11 +8,15 @@ import (
 	"github.com/gobwas/glob"
 )
 
+type FilepathChecker interface {
+	IsInclude(absFilepath string) (FilepathCheckerResult, error)
+}
+
 // Types for file path glob rule (include/exclude).
 type GlobRuleType bool
 
 // Types result of checking path with glob rules in [GlobRuleManager].
-type GlobRuleResult int
+type FilepathCheckerResult int
 
 const (
 	GlobIncludeRule GlobRuleType = false
@@ -20,7 +24,7 @@ const (
 )
 
 const (
-	GlobRuleDefault GlobRuleResult = iota
+	GlobRuleDefault FilepathCheckerResult = iota
 	GlobRuleInclude
 	GlobRuleExclude
 )
@@ -32,7 +36,7 @@ type GlobRuleManager struct {
 	excludeRules  []glob.Glob
 }
 
-func newGlobRuleManager(rootDir string, prefferedRule GlobRuleType, includeGlobRules, excludeGlobRules []string) (*GlobRuleManager, error) {
+func NewGlobRuleManager(rootDir string, prefferedRule GlobRuleType, includeGlobRules, excludeGlobRules []string) (*GlobRuleManager, error) {
 	manager := &GlobRuleManager{
 		rootDir:       rootDir,
 		prefferedRule: prefferedRule,
@@ -75,7 +79,7 @@ func compileRule(rootDir, rule string) (glob.Glob, error) {
 
 // Check if a file path meets the include/exclude conditions.
 // If it does not satisfy either conditions, will return [GlobRuleDefault].
-func (m *GlobRuleManager) IsInclude(path string) (GlobRuleResult, error) {
+func (m *GlobRuleManager) IsInclude(path string) (FilepathCheckerResult, error) {
 
 	abspath := func() string {
 		if filepath.IsAbs(path) {

--- a/fsnotify/glob_rule.go
+++ b/fsnotify/glob_rule.go
@@ -8,7 +8,11 @@ import (
 	"github.com/gobwas/glob"
 )
 
+// Check if a file path meets the include/exclude conditions.
+// If it does not satisfy either conditions, will return [FilepathCheckerDefault].
 type FilepathChecker interface {
+	// Check if a file path meets the include/exclude conditions.
+	// If it does not satisfy either conditions, will return [FilepathCheckerDefault].
 	IsInclude(absFilepath string) (FilepathCheckerResult, error)
 }
 
@@ -78,7 +82,7 @@ func compileRule(rootDir, rule string) (glob.Glob, error) {
 }
 
 // Check if a file path meets the include/exclude conditions.
-// If it does not satisfy either conditions, will return [GlobRuleDefault].
+// If it does not satisfy either conditions, will return [FilepathCheckerDefault].
 func (m *GlobRuleManager) IsInclude(path string) (FilepathCheckerResult, error) {
 
 	abspath := func() string {


### PR DESCRIPTION
## Backgrounds (Issues)
- #23 

## Changes
- `fsnotify.RouteWatch()` argument
- new interface type: `fsnotify.FilepathChecker`

## Checkpoint & Tips
